### PR TITLE
refactor: fix imports

### DIFF
--- a/app/[lang]/(clientPages)/layout.tsx
+++ b/app/[lang]/(clientPages)/layout.tsx
@@ -1,7 +1,9 @@
+import { ReactNode } from 'react';
+
 function ClientLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <>

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -4,7 +4,7 @@ import { hasLocale, NextIntlClientProvider } from 'next-intl';
 import ClientThemeProvider from '@/components/common/theme-provider';
 import { routing } from '@/i18n/routing';
 import { notFound } from 'next/navigation';
-import React from 'react';
+import { ReactNode } from 'react';
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -15,7 +15,7 @@ export default async function RootLayout({
   children,
   params,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
   params: Promise<{ lang: string }>;
 }>) {
   const { lang } = await params;

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import styles from './page.module.css';
 
 export default function Home() {

--- a/components/common/theme-provider.tsx
+++ b/components/common/theme-provider.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider, CssBaseline } from '@mui/material';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import theme from '@/theme';
 import { Roboto } from 'next/font/google';
-import React from 'react';
+import { ReactNode } from 'react';
 
 const roboto = Roboto({
   weight: ['300', '400', '500', '700'],
@@ -16,7 +16,7 @@ const roboto = Roboto({
 export default function ClientThemeProvider({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <div className={roboto.variable}>


### PR DESCRIPTION
- исправлены ошибки линтера
- предпочтительнее использовать named импорты.

Ошибки на текущей develop ветке:
<img width="386" height="122" alt="image" src="https://github.com/user-attachments/assets/d14d5894-f6d0-480d-b797-3134570318b5" />
